### PR TITLE
feat: buttons for l, mid and r added

### DIFF
--- a/src/assets/icons/PanningLegend.tsx
+++ b/src/assets/icons/PanningLegend.tsx
@@ -44,10 +44,13 @@ export const PanningLegend = () => {
         y2="35"
         style={{ stroke: '#777', strokeWidth: 2 }}
       />
-      <text x="2" y="46" className="text-[10px] font-sans fill-[#777]">
+      <text x="2" y="50" className="text-[10px] font-sans fill-[#777]">
         L
       </text>
-      <text x="72" y="46" className="text-[10px] font-sans fill-[#777]">
+      <text x="37" y="50" className="text-[10px] font-sans fill-[#777]">
+        0
+      </text>
+      <text x="72" y="50" className="text-[10px] font-sans fill-[#777]">
         R
       </text>
     </svg>

--- a/src/components/strips/stripComponents/panningSlider/PanningSlider.tsx
+++ b/src/components/strips/stripComponents/panningSlider/PanningSlider.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { PanningLegend } from '../../../../assets/icons/PanningLegend';
 import debounce from 'lodash/debounce';
+import { SetValueButtons } from './SetValueButtons';
 
 type PanningSliderProps = {
   inputValue: number;
@@ -42,6 +43,7 @@ export const PanningSlider = ({ inputValue, onChange }: PanningSliderProps) => {
   return (
     <div className="relative w-[80px] h-[50px] mb-3">
       <PanningLegend />
+      <SetValueButtons onChange={onChange} />
       <input
         type="range"
         className="absolute w-[80px] h-[5px] left-[2px] bg-[#d3d3d3] outline-none

--- a/src/components/strips/stripComponents/panningSlider/SetValueButtons.tsx
+++ b/src/components/strips/stripComponents/panningSlider/SetValueButtons.tsx
@@ -1,0 +1,25 @@
+export const SetValueButtons = ({
+  onChange
+}: {
+  onChange: (value: number) => void;
+}) => {
+  const valueButton = () => {
+    const inputs = [
+      { value: 0, position: 'left-[-2px]' },
+      { value: 64, position: 'right-[27px]' },
+      { value: 128, position: 'right-[-7px]' }
+    ];
+    return inputs.map((input: { value: number; position: string }) => (
+      <button
+        key={input.value}
+        type="button"
+        className={`absolute bottom-[-7px] ${input.position} w-[20px] h-[20px] hover:bg-almost-white rounded-md hover:opacity-10`}
+        onClick={() => {
+          onChange(input.value);
+        }}
+      />
+    ));
+  };
+
+  return <div className="flex flex-row">{valueButton()}</div>;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@
   }
 
   .pan-slider-thumb {
-    @apply appearance-none w-[15px] h-[50px] bg-slider-green rounded-lg cursor-pointer;
+    @apply appearance-none w-[10px] h-[40px] bg-slider-green rounded-lg cursor-pointer;
   }
 
   .slider-track {


### PR DESCRIPTION
Buttons under pan-slider to set the value to L (-1), 0 or R (1).

<img width="100" alt="Screenshot 2025-03-10 at 08 39 52" src="https://github.com/user-attachments/assets/a5edc652-8ab7-4052-95ee-baf0c5f8cde2" />

on hover:
<img width="100" alt="Screenshot 2025-03-10 at 08 40 03" src="https://github.com/user-attachments/assets/ce596f9d-a5ae-4fe0-86ef-0a3d840edc23" />
