### PR TITLE
fix: added limit to header-length and full-label on hover

### DIFF
--- a/src/components/strips/stripComponents/stripHeader/StripHeader.tsx
+++ b/src/components/strips/stripComponents/stripHeader/StripHeader.tsx
@@ -32,7 +32,12 @@ export const StripHeader: React.FC<StripHeaderProps> = ({
     <div
       className={`flex justify-between flex-wrap items-center w-full px-4 py-3 ${configMode ? 'bg-selected-mix-bg border border-selected-mix-border border-b-0 rounded-t-lg' : ''}`}
     >
-      <div className="text-base text-center text-white">{label}</div>
+      <div
+        className="max-w-[4rem] text-base text-center text-white truncate"
+        title={label}
+      >
+        {label}
+      </div>
       {copyButton && (
         <button onClick={onCopy} className="w-[2rem]">
           <Icons


### PR DESCRIPTION
<img width="448" alt="Screenshot 2025-03-11 at 16 15 39" src="https://github.com/user-attachments/assets/6d1c23bc-650e-4093-8ec6-f2e2244f4076" />
<br/>
<img width="326" alt="Screenshot 2025-03-11 at 16 15 56" src="https://github.com/user-attachments/assets/581ca7a4-11ff-407b-9979-de17aa2bac22" />
